### PR TITLE
validations: validate out degree

### DIFF
--- a/validation/validators/refs.go
+++ b/validation/validators/refs.go
@@ -54,28 +54,28 @@ func (v *RefsValidator) validateParent(ctx context.Context, r store.SegmentReade
 		return nil
 	}
 
-	s, err := r.GetSegment(ctx, l.PrevLinkHash())
+	parent, err := r.GetSegment(ctx, l.PrevLinkHash())
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	if s == nil || s.Link == nil {
+	if parent == nil || parent.Link == nil {
 		return ErrParentNotFound
 	}
 
-	if s.Link.Meta.Process.Name != l.Meta.Process.Name {
+	if parent.Link.Meta.Process.Name != l.Meta.Process.Name {
 		return ErrProcessMismatch
 	}
 
-	if s.Link.Meta.MapId != l.Meta.MapId {
+	if parent.Link.Meta.MapId != l.Meta.MapId {
 		return ErrMapIDMismatch
 	}
 
-	if s.Link.Meta.OutDegree == 0 {
+	if parent.Link.Meta.OutDegree == 0 {
 		return chainscript.ErrOutDegree
 	}
 
-	if s.Link.Meta.OutDegree > 0 {
+	if parent.Link.Meta.OutDegree > 0 {
 		children, err := r.FindSegments(ctx, &store.SegmentFilter{
 			Pagination:   store.Pagination{Limit: 1},
 			PrevLinkHash: l.PrevLinkHash(),
@@ -84,7 +84,7 @@ func (v *RefsValidator) validateParent(ctx context.Context, r store.SegmentReade
 			return errors.WithStack(err)
 		}
 
-		if int(s.Link.Meta.OutDegree) <= children.TotalCount {
+		if int(parent.Link.Meta.OutDegree) <= children.TotalCount {
 			return chainscript.ErrOutDegree
 		}
 	}

--- a/validation/validators/refs.go
+++ b/validation/validators/refs.go
@@ -42,60 +42,94 @@ func NewRefsValidator() Validator {
 
 // Validate all references (parent and refs).
 func (v *RefsValidator) Validate(ctx context.Context, r store.SegmentReader, l *chainscript.Link) error {
-	if len(l.PrevLinkHash()) > 0 {
-		s, err := r.GetSegment(ctx, l.PrevLinkHash())
-		if err != nil {
-			return errors.WithStack(err)
-		}
-
-		if s == nil || s.Link == nil {
-			return ErrParentNotFound
-		}
-
-		if s.Link.Meta.Process.Name != l.Meta.Process.Name {
-			return ErrProcessMismatch
-		}
-
-		if s.Link.Meta.MapId != l.Meta.MapId {
-			return ErrMapIDMismatch
-		}
+	if err := v.validateParent(ctx, r, l); err != nil {
+		return err
 	}
 
-	if len(l.Meta.Refs) > 0 {
-		var lhs []chainscript.LinkHash
-		for _, ref := range l.Meta.Refs {
-			lhs = append(lhs, ref.LinkHash)
-		}
+	return v.validateReferences(ctx, r, l)
+}
 
-		segments, err := r.FindSegments(ctx, &store.SegmentFilter{
-			Pagination: store.Pagination{Limit: len(lhs)},
-			LinkHashes: lhs,
+func (v *RefsValidator) validateParent(ctx context.Context, r store.SegmentReader, l *chainscript.Link) error {
+	if len(l.PrevLinkHash()) == 0 {
+		return nil
+	}
+
+	s, err := r.GetSegment(ctx, l.PrevLinkHash())
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	if s == nil || s.Link == nil {
+		return ErrParentNotFound
+	}
+
+	if s.Link.Meta.Process.Name != l.Meta.Process.Name {
+		return ErrProcessMismatch
+	}
+
+	if s.Link.Meta.MapId != l.Meta.MapId {
+		return ErrMapIDMismatch
+	}
+
+	if s.Link.Meta.OutDegree == 0 {
+		return chainscript.ErrOutDegree
+	}
+
+	if s.Link.Meta.OutDegree > 0 {
+		children, err := r.FindSegments(ctx, &store.SegmentFilter{
+			Pagination:   store.Pagination{Limit: 1},
+			PrevLinkHash: l.PrevLinkHash(),
 		})
 		if err != nil {
 			return errors.WithStack(err)
 		}
 
-		if len(segments.Segments) != len(l.Meta.Refs) {
-			return ErrRefNotFound
+		if int(s.Link.Meta.OutDegree) <= children.TotalCount {
+			return chainscript.ErrOutDegree
+		}
+	}
+
+	return nil
+}
+
+func (v *RefsValidator) validateReferences(ctx context.Context, r store.SegmentReader, l *chainscript.Link) error {
+	if len(l.Meta.Refs) == 0 {
+		return nil
+	}
+
+	var lhs []chainscript.LinkHash
+	for _, ref := range l.Meta.Refs {
+		lhs = append(lhs, ref.LinkHash)
+	}
+
+	segments, err := r.FindSegments(ctx, &store.SegmentFilter{
+		Pagination: store.Pagination{Limit: len(lhs)},
+		LinkHashes: lhs,
+	})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	if len(segments.Segments) != len(l.Meta.Refs) {
+		return ErrRefNotFound
+	}
+
+	for _, ref := range l.Meta.Refs {
+		found := false
+
+		for _, s := range segments.Segments {
+			if bytes.Equal(ref.LinkHash, s.LinkHash()) {
+				found = true
+				if ref.Process != s.Link.Meta.Process.Name {
+					return ErrProcessMismatch
+				}
+
+				break
+			}
 		}
 
-		for _, ref := range l.Meta.Refs {
-			found := false
-
-			for _, s := range segments.Segments {
-				if bytes.Equal(ref.LinkHash, s.LinkHash()) {
-					found = true
-					if ref.Process != s.Link.Meta.Process.Name {
-						return ErrProcessMismatch
-					}
-
-					break
-				}
-			}
-
-			if !found {
-				return ErrRefNotFound
-			}
+		if !found {
+			return ErrRefNotFound
 		}
 	}
 


### PR DESCRIPTION
Adding out degree validation in the refs validator.
For all cases where a consensus algorithm runs (Tendermint, Kayak, etc) it will be enough to validate here and any store can be used underneath (even if it doesn't have built-in support like postgresstore).

Later we will provide more configuration hooks at the store level so that we can bypass the validations done in the store (like postgresstore's outDegree tables) if it has been validated upstream (at the consensus layer).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-core/447)
<!-- Reviewable:end -->
