### PR TITLE
btc: simplify balance calculation

### DIFF
--- a/blockchain/btc/blockcypher/blockcypher.go
+++ b/blockchain/btc/blockcypher/blockcypher.go
@@ -98,6 +98,8 @@ func (c *Client) FindUnspent(address *types.ReversedBytes20, amount int64) (res 
 		return
 	}
 
+	res.Total = int64(addrInfo.Balance)
+
 	for _, TXRef := range addrInfo.TXRefs {
 		output := btc.Output{Index: TXRef.TXOutputN}
 
@@ -110,23 +112,20 @@ func (c *Client) FindUnspent(address *types.ReversedBytes20, amount int64) (res 
 			return
 		}
 
-		res.Total += int64(TXRef.Value)
+		res.Outputs = append(res.Outputs, output)
+		res.Sum += int64(TXRef.Value)
 
-		if res.Sum < amount {
-			res.Outputs = append(res.Outputs, output)
-			res.Sum += int64(TXRef.Value)
-
+		if res.Sum >= amount {
+			return
 		}
 	}
 
-	if res.Sum < amount {
-		err = fmt.Errorf(
-			"not enough Bitcoins available on %s, expected at least %d satoshis got %d",
-			addr,
-			amount,
-			res.Sum,
-		)
-	}
+	err = fmt.Errorf(
+		"not enough Bitcoins available on %s, expected at least %d satoshis got %d",
+		addr,
+		amount,
+		res.Sum,
+	)
 
 	return
 }


### PR DESCRIPTION
I think that because of the pagination of the Blockcypher API, the calculated balance could be too small because it didn't include all the unspent outputs. It's much simpler to use the balance returned by the API anyways, I don't know why I didn't do that before!