### PR TITLE
validation: file watcher

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -149,6 +149,14 @@
   revision = "95f809107225be108efcf10a3509e4ea6ceef3c4"
 
 [[projects]]
+  digest = "1:eb53021a8aa3f599d29c7102e65026242bdedce998a54837dc67f14b6a97c5fd"
+  name = "github.com/fsnotify/fsnotify"
+  packages = ["."]
+  pruneopts = ""
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  version = "v1.4.7"
+
+[[projects]]
   digest = "1:a75c13601b74702838bc8b149402caa5618e825e629b1192fb983834a0950206"
   name = "github.com/gibson042/canonicaljson-go"
   packages = ["."]
@@ -814,6 +822,7 @@
     "github.com/btcsuite/btcutil",
     "github.com/btcsuite/btcutil/base58",
     "github.com/docker/go-connections/nat",
+    "github.com/fsnotify/fsnotify",
     "github.com/gibson042/canonicaljson-go",
     "github.com/golang/mock/gomock",
     "github.com/gorilla/websocket",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -7,18 +7,6 @@
   name = "github.com/tendermint/tendermint"
   version = "0.18.0"
 
-[[constraint]]
-  branch = "master"
-  name = "github.com/xeipuuv/gojsonschema"
-
-[[constraint]]
-  branch = "master"
-  name = "golang.org/x/crypto"
-
-[[constraint]]
-  name = "github.com/golang/mock"
-  branch="master"
-
 [[override]] 
   # This is required because Tendermint needs ~1.0.0
   # but Docker claims it needs ^0.4.
@@ -30,11 +18,6 @@
   name = "github.com/golang/protobuf"
   version = "^1.0.0"
 
-[[override]]
-  name = "github.com/chzyer/readline"
-  branch = "fix-bell"
-  source = "github.com/stratumn/readline"
-
 [[constraint]]
   name = "go.opencensus.io"
   branch = "master"
@@ -42,3 +25,7 @@
 [[constraint]]
   name = "github.com/stratumn/go-chainscript"
   branch = "master"
+
+[[constraint]]
+  name = "github.com/fsnotify/fsnotify"
+  version = "1.4.7"

--- a/cmd/couchstore/main.go
+++ b/cmd/couchstore/main.go
@@ -77,5 +77,5 @@ func main() {
 		log.Fatal(err)
 	}
 
-	storehttp.RunWithFlags(monitoring.NewStoreAdapter(a, "couchstore"))
+	storehttp.RunWithFlags(monitoring.WrapStore(a, "couchstore"))
 }

--- a/cmd/dummystore/main.go
+++ b/cmd/dummystore/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stratumn/go-core/dummystore"
 	"github.com/stratumn/go-core/monitoring"
 	"github.com/stratumn/go-core/store/storehttp"
+	"github.com/stratumn/go-core/validation"
 )
 
 var (
@@ -32,14 +33,20 @@ var (
 func init() {
 	storehttp.RegisterFlags()
 	monitoring.RegisterFlags()
+	validation.RegisterFlags()
 }
 
 func main() {
 	flag.Parse()
 	log.Infof("%s v%s@%s", dummystore.Description, version, commit[:7])
-	a := monitoring.NewStoreAdapter(
+
+	a, err := validation.WrapStoreWithConfigFile(
 		dummystore.New(&dummystore.Config{Version: version, Commit: commit}),
-		"dummystore",
+		validation.ConfigurationFromFlags(),
 	)
-	storehttp.RunWithFlags(a)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	storehttp.RunWithFlags(monitoring.NewStoreAdapter(a, "dummystore"))
 }

--- a/cmd/dummystore/main.go
+++ b/cmd/dummystore/main.go
@@ -48,5 +48,5 @@ func main() {
 		log.Fatal(err)
 	}
 
-	storehttp.RunWithFlags(monitoring.NewStoreAdapter(a, "dummystore"))
+	storehttp.RunWithFlags(monitoring.WrapStore(a, "dummystore"))
 }

--- a/cmd/dummytmpop/main.go
+++ b/cmd/dummytmpop/main.go
@@ -47,8 +47,8 @@ func main() {
 		Monitoring: monitoring.ConfigurationFromFlags(),
 	}
 	tmpop.Run(
-		monitoring.NewStoreAdapter(a, "dummystore"),
-		monitoring.NewKeyValueStoreAdapter(a, "dummystore"),
+		monitoring.WrapStore(a, "dummystore"),
+		monitoring.WrapKeyValueStore(a, "dummystore"),
 		tmpopConfig,
 	)
 }

--- a/cmd/elasticsearchstore/main.go
+++ b/cmd/elasticsearchstore/main.go
@@ -50,5 +50,5 @@ func main() {
 		log.Fatal(err)
 	}
 
-	storehttp.RunWithFlags(monitoring.NewStoreAdapter(a, "elasticsearchstore"))
+	storehttp.RunWithFlags(monitoring.WrapStore(a, "elasticsearchstore"))
 }

--- a/cmd/elasticsearchtmpop/main.go
+++ b/cmd/elasticsearchtmpop/main.go
@@ -48,8 +48,8 @@ func main() {
 		Monitoring: monitoring.ConfigurationFromFlags(),
 	}
 	tmpop.Run(
-		monitoring.NewStoreAdapter(a, "elasticsearchstore"),
-		monitoring.NewKeyValueStoreAdapter(a, "elasticsearchstore"),
+		monitoring.WrapStore(a, "elasticsearchstore"),
+		monitoring.WrapKeyValueStore(a, "elasticsearchstore"),
 		tmpopConfig,
 	)
 }

--- a/cmd/filestore/main.go
+++ b/cmd/filestore/main.go
@@ -59,5 +59,5 @@ func main() {
 		log.Fatal(err)
 	}
 
-	storehttp.RunWithFlags(monitoring.NewStoreAdapter(a, "filestore"))
+	storehttp.RunWithFlags(monitoring.WrapStore(a, "filestore"))
 }

--- a/cmd/filestore/main.go
+++ b/cmd/filestore/main.go
@@ -21,7 +21,9 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stratumn/go-core/filestore"
 	"github.com/stratumn/go-core/monitoring"
+	"github.com/stratumn/go-core/store"
 	"github.com/stratumn/go-core/store/storehttp"
+	"github.com/stratumn/go-core/validation"
 )
 
 var (
@@ -33,12 +35,17 @@ var (
 func init() {
 	storehttp.RegisterFlags()
 	monitoring.RegisterFlags()
+	validation.RegisterFlags()
 }
 
 func main() {
 	flag.Parse()
 	log.Infof("%s v%s@%s", filestore.Description, version, commit[:7])
-	a, err := filestore.New(&filestore.Config{
+
+	var err error
+	var a store.Adapter
+
+	a, err = filestore.New(&filestore.Config{
 		Path:    *path,
 		Version: version,
 		Commit:  commit,
@@ -46,5 +53,11 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	a, err = validation.WrapStoreWithConfigFile(a, validation.ConfigurationFromFlags())
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	storehttp.RunWithFlags(monitoring.NewStoreAdapter(a, "filestore"))
 }

--- a/cmd/filetmpop/main.go
+++ b/cmd/filetmpop/main.go
@@ -53,8 +53,8 @@ func main() {
 		Monitoring: monitoring.ConfigurationFromFlags(),
 	}
 	tmpop.Run(
-		monitoring.NewStoreAdapter(a, "filestore"),
-		monitoring.NewKeyValueStoreAdapter(a, "filestore"),
+		monitoring.WrapStore(a, "filestore"),
+		monitoring.WrapKeyValueStore(a, "filestore"),
 		tmpopConfig,
 	)
 }

--- a/cmd/postgresstore/main.go
+++ b/cmd/postgresstore/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stratumn/go-core/monitoring"
 	"github.com/stratumn/go-core/postgresstore"
 	"github.com/stratumn/go-core/store/storehttp"
+	"github.com/stratumn/go-core/validation"
 )
 
 var (
@@ -33,16 +34,20 @@ func init() {
 	storehttp.RegisterFlags()
 	postgresstore.RegisterFlags()
 	monitoring.RegisterFlags()
+	validation.RegisterFlags()
 }
 
 func main() {
 	flag.Parse()
-
 	log.Infof("%s v%s@%s", postgresstore.Description, version, commit[:7])
 
-	a := monitoring.NewStoreAdapter(
+	a, err := validation.WrapStoreWithConfigFile(
 		postgresstore.InitializeWithFlags(version, commit),
-		"postgresstore",
+		validation.ConfigurationFromFlags(),
 	)
-	storehttp.RunWithFlags(a)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	storehttp.RunWithFlags(monitoring.NewStoreAdapter(a, "postgresstore"))
 }

--- a/cmd/postgresstore/main.go
+++ b/cmd/postgresstore/main.go
@@ -49,5 +49,5 @@ func main() {
 		log.Fatal(err)
 	}
 
-	storehttp.RunWithFlags(monitoring.NewStoreAdapter(a, "postgresstore"))
+	storehttp.RunWithFlags(monitoring.WrapStore(a, "postgresstore"))
 }

--- a/cmd/postgrestmpop/main.go
+++ b/cmd/postgrestmpop/main.go
@@ -48,8 +48,8 @@ func main() {
 		Monitoring: monitoring.ConfigurationFromFlags(),
 	}
 	tmpop.Run(
-		monitoring.NewStoreAdapter(a, "postgresstore"),
-		monitoring.NewKeyValueStoreAdapter(a, "postgresstore"),
+		monitoring.WrapStore(a, "postgresstore"),
+		monitoring.WrapKeyValueStore(a, "postgresstore"),
 		tmpopConfig,
 	)
 }

--- a/cmd/rethinkstore/main.go
+++ b/cmd/rethinkstore/main.go
@@ -49,5 +49,5 @@ func main() {
 		log.Fatal(err)
 	}
 
-	storehttp.RunWithFlags(monitoring.NewStoreAdapter(a, "rethinkstore"))
+	storehttp.RunWithFlags(monitoring.WrapStore(a, "rethinkstore"))
 }

--- a/cmd/rethinktmpop/main.go
+++ b/cmd/rethinktmpop/main.go
@@ -48,8 +48,8 @@ func main() {
 		Monitoring: monitoring.ConfigurationFromFlags(),
 	}
 	tmpop.Run(
-		monitoring.NewStoreAdapter(a, "rethinkstore"),
-		monitoring.NewKeyValueStoreAdapter(a, "rethinkstore"),
+		monitoring.WrapStore(a, "rethinkstore"),
+		monitoring.WrapKeyValueStore(a, "rethinkstore"),
 		tmpopConfig,
 	)
 }

--- a/cmd/tmstore/main.go
+++ b/cmd/tmstore/main.go
@@ -57,5 +57,5 @@ func main() {
 		}
 	}()
 
-	storehttp.RunWithFlags(monitoring.NewStoreAdapter(a, "tmstore"))
+	storehttp.RunWithFlags(monitoring.WrapStore(a, "tmstore"))
 }

--- a/couchstore/couchstore.go
+++ b/couchstore/couchstore.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stratumn/go-core/bufferedbatch"
 	"github.com/stratumn/go-core/store"
 	"github.com/stratumn/go-core/types"
-	"github.com/stratumn/go-core/validation/validators"
 )
 
 const (
@@ -142,14 +141,6 @@ func (c *CouchStore) notifyEvent(event *store.Event) {
 
 // CreateLink implements github.com/stratumn/go-core/store.LinkWriter.CreateLink.
 func (c *CouchStore) CreateLink(ctx context.Context, link *chainscript.Link) (chainscript.LinkHash, error) {
-	if err := link.Validate(ctx); err != nil {
-		return nil, err
-	}
-
-	if err := validators.NewRefsValidator().Validate(ctx, c, link); err != nil {
-		return nil, err
-	}
-
 	if link.Meta.OutDegree >= 0 {
 		return nil, store.ErrOutDegreeNotSupported
 	}

--- a/dummystore/dummystore.go
+++ b/dummystore/dummystore.go
@@ -29,7 +29,6 @@ import (
 	"github.com/stratumn/go-core/bufferedbatch"
 	"github.com/stratumn/go-core/store"
 	"github.com/stratumn/go-core/types"
-	"github.com/stratumn/go-core/validation/validators"
 )
 
 const (
@@ -109,14 +108,6 @@ func (a *DummyStore) AddStoreEventChannel(eventChan chan *store.Event) {
 
 // CreateLink implements github.com/stratumn/go-core/store.LinkWriter.CreateLink.
 func (a *DummyStore) CreateLink(ctx context.Context, link *chainscript.Link) (chainscript.LinkHash, error) {
-	if err := link.Validate(ctx); err != nil {
-		return nil, err
-	}
-
-	if err := validators.NewRefsValidator().Validate(ctx, a, link); err != nil {
-		return nil, err
-	}
-
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 

--- a/elasticsearchstore/elasticsearchstore.go
+++ b/elasticsearchstore/elasticsearchstore.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stratumn/go-core/bufferedbatch"
 	"github.com/stratumn/go-core/store"
 	"github.com/stratumn/go-core/types"
-	"github.com/stratumn/go-core/validation/validators"
 )
 
 const (
@@ -154,14 +153,6 @@ func (es *ESStore) NewBatch(ctx context.Context) (store.Batch, error) {
 
 // CreateLink implements github.com/stratumn/go-core/store.LinkWriter.CreateLink.
 func (es *ESStore) CreateLink(ctx context.Context, link *chainscript.Link) (chainscript.LinkHash, error) {
-	if err := link.Validate(ctx); err != nil {
-		return nil, err
-	}
-
-	if err := validators.NewRefsValidator().Validate(ctx, es, link); err != nil {
-		return nil, err
-	}
-
 	if link.Meta.OutDegree >= 0 {
 		return nil, store.ErrOutDegreeNotSupported
 	}

--- a/filestore/filestore.go
+++ b/filestore/filestore.go
@@ -39,7 +39,6 @@ import (
 	"github.com/stratumn/go-core/monitoring"
 	"github.com/stratumn/go-core/store"
 	"github.com/stratumn/go-core/types"
-	"github.com/stratumn/go-core/validation/validators"
 )
 
 const (
@@ -125,14 +124,6 @@ func (a *FileStore) NewBatch(ctx context.Context) (store.Batch, error) {
 
 // CreateLink implements github.com/stratumn/go-core/store.LinkWriter.CreateLink.
 func (a *FileStore) CreateLink(ctx context.Context, link *chainscript.Link) (chainscript.LinkHash, error) {
-	if err := link.Validate(ctx); err != nil {
-		return nil, err
-	}
-
-	if err := validators.NewRefsValidator().Validate(ctx, a, link); err != nil {
-		return nil, err
-	}
-
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 

--- a/filestore/filestore.go
+++ b/filestore/filestore.go
@@ -94,7 +94,7 @@ func New(config *Config) (*FileStore, error) {
 		config:     config,
 		eventChans: nil,
 		mutex:      sync.RWMutex{},
-		kvDB:       monitoring.NewKeyValueStoreAdapter(db, "leveldbstore"),
+		kvDB:       monitoring.WrapKeyValueStore(db, "leveldbstore"),
 	}, nil
 }
 

--- a/monitoring/store.go
+++ b/monitoring/store.go
@@ -32,8 +32,8 @@ type StoreAdapter struct {
 	name string
 }
 
-// NewStoreAdapter decorates an existing store adapter.
-func NewStoreAdapter(s store.Adapter, name string) store.Adapter {
+// WrapStore wraps an existing store adapter to add monitoring.
+func WrapStore(s store.Adapter, name string) store.Adapter {
 	return &StoreAdapter{s: s, name: name}
 }
 
@@ -121,8 +121,9 @@ type KeyValueStoreAdapter struct {
 	name string
 }
 
-// NewKeyValueStoreAdapter decorates an existing key value store adapter.
-func NewKeyValueStoreAdapter(s store.KeyValueStore, name string) store.KeyValueStore {
+// WrapKeyValueStore wraps an existing key value store adapter to add
+// monitoring.
+func WrapKeyValueStore(s store.KeyValueStore, name string) store.KeyValueStore {
 	return &KeyValueStoreAdapter{s: s, name: name}
 }
 

--- a/postgresstore/postgresstore.go
+++ b/postgresstore/postgresstore.go
@@ -24,7 +24,6 @@ import (
 	"github.com/lib/pq"
 	"github.com/stratumn/go-chainscript"
 	"github.com/stratumn/go-core/store"
-	"github.com/stratumn/go-core/validation/validators"
 )
 
 const (
@@ -145,14 +144,6 @@ func (a *Store) AddStoreEventChannel(eventChan chan *store.Event) {
 
 // CreateLink implements github.com/stratumn/go-core/store.LinkWriter.CreateLink.
 func (a *Store) CreateLink(ctx context.Context, link *chainscript.Link) (chainscript.LinkHash, error) {
-	if err := link.Validate(ctx); err != nil {
-		return nil, err
-	}
-
-	if err := validators.NewRefsValidator().Validate(ctx, a, link); err != nil {
-		return nil, err
-	}
-
 	linkHash, err := a.scopedStore.CreateLink(ctx, link)
 	if err != nil {
 		return nil, err

--- a/rethinkstore/rethinkstore.go
+++ b/rethinkstore/rethinkstore.go
@@ -30,7 +30,6 @@ import (
 	"github.com/stratumn/go-core/store"
 	"github.com/stratumn/go-core/types"
 	"github.com/stratumn/go-core/utils"
-	"github.com/stratumn/go-core/validation/validators"
 
 	rethink "gopkg.in/dancannon/gorethink.v4"
 )
@@ -192,14 +191,6 @@ func formatLink(link *chainscript.Link) {
 
 // CreateLink implements github.com/stratumn/go-core/store.LinkWriter.CreateLink.
 func (a *Store) CreateLink(ctx context.Context, link *chainscript.Link) (chainscript.LinkHash, error) {
-	if err := link.Validate(ctx); err != nil {
-		return nil, err
-	}
-
-	if err := validators.NewRefsValidator().Validate(ctx, a, link); err != nil {
-		return nil, err
-	}
-
 	if link.Meta.OutDegree >= 0 {
 		return nil, store.ErrOutDegreeNotSupported
 	}

--- a/validation/filewrapper.go
+++ b/validation/filewrapper.go
@@ -24,6 +24,6 @@ type StoreWithConfigFile struct {
 
 // WrapStoreWithConfigFile wraps a store adapter with a layer of validations
 // based on a local configuration file.
-func WrapStoreWithConfigFile(a store.Adapter) store.Adapter {
-	return &StoreWithConfigFile{Adapter: a}
+func WrapStoreWithConfigFile(a store.Adapter, cfg *Config) (store.Adapter, error) {
+	return &StoreWithConfigFile{Adapter: a}, nil
 }

--- a/validation/filewrapper.go
+++ b/validation/filewrapper.go
@@ -1,0 +1,29 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import "github.com/stratumn/go-core/store"
+
+// StoreWithConfigFile wraps a store adapter with a layer of validations
+// based on a local configuration file.
+type StoreWithConfigFile struct {
+	store.Adapter
+}
+
+// WrapStoreWithConfigFile wraps a store adapter with a layer of validations
+// based on a local configuration file.
+func WrapStoreWithConfigFile(a store.Adapter) store.Adapter {
+	return &StoreWithConfigFile{Adapter: a}
+}

--- a/validation/filewrapper.go
+++ b/validation/filewrapper.go
@@ -17,7 +17,10 @@ package validation
 import (
 	"context"
 	"os"
+	"sync"
 
+	"github.com/fsnotify/fsnotify"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/stratumn/go-chainscript"
 	"github.com/stratumn/go-core/store"
@@ -30,6 +33,9 @@ type StoreWithConfigFile struct {
 	store.Adapter
 
 	defaultValidator validators.Validator
+
+	lock            sync.RWMutex
+	customValidator validators.Validator
 }
 
 // WrapStoreWithConfigFile wraps a store adapter with a layer of validations
@@ -42,23 +48,40 @@ func WrapStoreWithConfigFile(a store.Adapter, cfg *Config) (store.Adapter, error
 		validators.NewRefsValidator(),
 	})
 
+	wrapped := &StoreWithConfigFile{
+		Adapter:          a,
+		defaultValidator: defaultValidator,
+	}
+
 	if cfg == nil || len(cfg.RulesPath) == 0 {
 		log.Warn("No custom validation rules provided. Only default link validations will be applied.")
-		return &StoreWithConfigFile{
-			Adapter:          a,
-			defaultValidator: defaultValidator,
-		}, nil
+		return wrapped, nil
 	}
 
 	if _, err := os.Stat(cfg.RulesPath); os.IsNotExist(err) {
 		log.Warnf("Invalid custom validation rules path: could not load rules at %s", cfg.RulesPath)
-		return &StoreWithConfigFile{
-			Adapter:          a,
-			defaultValidator: defaultValidator,
-		}, nil
+		return wrapped, nil
 	}
 
-	return nil, nil
+	v, err := LoadFromFile(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	wrapped.customValidator = validators.NewMultiValidator(v.Flatten())
+
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	if err := w.Add(cfg.RulesPath); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	go wrapped.watchRules(w, cfg)
+
+	return wrapped, nil
 }
 
 // CreateLink applies validations before creating the link.
@@ -71,5 +94,37 @@ func (a *StoreWithConfigFile) CreateLink(ctx context.Context, link *chainscript.
 		return nil, err
 	}
 
+	if err := a.validateCustom(ctx, link); err != nil {
+		return nil, err
+	}
+
 	return a.Adapter.CreateLink(ctx, link)
+}
+
+func (a *StoreWithConfigFile) validateCustom(ctx context.Context, link *chainscript.Link) error {
+	a.lock.RLock()
+	defer a.lock.RUnlock()
+
+	if a.customValidator == nil {
+		return nil
+	}
+
+	return a.customValidator.Validate(ctx, a, link)
+}
+
+func (a *StoreWithConfigFile) watchRules(w *fsnotify.Watcher, cfg *Config) {
+	for e := range w.Events {
+		if e.Op != fsnotify.Write {
+			continue
+		}
+
+		newValidators, err := LoadFromFile(cfg)
+		if err != nil {
+			continue
+		}
+
+		a.lock.Lock()
+		a.customValidator = validators.NewMultiValidator(newValidators.Flatten())
+		a.lock.Unlock()
+	}
 }

--- a/validation/filewrapper_test.go
+++ b/validation/filewrapper_test.go
@@ -1,0 +1,35 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStoreWithConfigFile(t *testing.T) {
+	t.Run("valid link", func(t *testing.T) {
+		assert.Fail(t, "TODO")
+	})
+
+	t.Run("invalid link", func(t *testing.T) {
+		assert.Fail(t, "TODO")
+	})
+
+	t.Run("config file update", func(t *testing.T) {
+		assert.Fail(t, "TODO")
+	})
+}

--- a/validation/filewrapper_test.go
+++ b/validation/filewrapper_test.go
@@ -15,21 +15,202 @@
 package validation_test
 
 import (
+	"context"
+	"io/ioutil"
+	"os"
 	"testing"
 
+	"github.com/stratumn/go-chainscript"
+	"github.com/stratumn/go-chainscript/chainscripttest"
+	"github.com/stratumn/go-core/dummystore"
+	"github.com/stratumn/go-core/utils"
+	"github.com/stratumn/go-core/validation"
+	"github.com/stratumn/go-core/validation/validationtesting"
+	"github.com/stratumn/go-core/validation/validators"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStoreWithConfigFile(t *testing.T) {
-	t.Run("valid link", func(t *testing.T) {
-		assert.Fail(t, "TODO")
+	testStore := dummystore.New(nil)
+
+	t.Run("without configuration file", func(t *testing.T) {
+		t.Run("invalid link", func(t *testing.T) {
+			va, err := validation.WrapStoreWithConfigFile(testStore, &validation.Config{})
+			require.NoError(t, err)
+
+			link := chainscripttest.NewLinkBuilder(t).WithProcess("").Build()
+			_, err = va.CreateLink(context.Background(), link)
+			assert.EqualError(t, err, chainscript.ErrMissingProcess.Error())
+		})
+
+		t.Run("valid link", func(t *testing.T) {
+			va, err := validation.WrapStoreWithConfigFile(testStore, &validation.Config{})
+			require.NoError(t, err)
+
+			link := chainscripttest.NewLinkBuilder(t).WithRandomData().Build()
+			_, err = va.CreateLink(context.Background(), link)
+			assert.NoError(t, err)
+		})
 	})
 
-	t.Run("invalid link", func(t *testing.T) {
-		assert.Fail(t, "TODO")
-	})
+	t.Run("with configuration file", func(t *testing.T) {
+		rules := utils.CreateTempFile(t, validationtesting.TestJSONRules)
+		defer os.Remove(rules)
 
-	t.Run("config file update", func(t *testing.T) {
-		assert.Fail(t, "TODO")
+		testValidationStore, err := validation.WrapStoreWithConfigFile(
+			testStore,
+			&validation.Config{RulesPath: rules},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, testValidationStore)
+
+		t.Run("invalid link", func(t *testing.T) {
+			link := chainscripttest.NewLinkBuilder(t).
+				WithProcess("").
+				Build()
+
+			_, err := testValidationStore.CreateLink(context.Background(), link)
+			assert.EqualError(t, err, chainscript.ErrMissingProcess.Error())
+		})
+
+		t.Run("missing parent", func(t *testing.T) {
+			link := chainscripttest.NewLinkBuilder(t).
+				WithProcess("chat").
+				WithParentHash(chainscripttest.RandomHash()).
+				Build()
+
+			_, err := testValidationStore.CreateLink(context.Background(), link)
+			assert.EqualError(t, err, validators.ErrParentNotFound.Error())
+		})
+
+		t.Run("invalid transition", func(t *testing.T) {
+			ctx := context.Background()
+			init := chainscripttest.NewLinkBuilder(t).
+				WithProcess("chat").
+				WithStep("init").
+				WithSignatureFromKey(t, []byte(validationtesting.BobPrivateKey), "").
+				Build()
+
+			_, err := testValidationStore.CreateLink(ctx, init)
+			require.NoError(t, err)
+
+			init2 := chainscripttest.NewLinkBuilder(t).
+				WithProcess("chat").
+				WithStep("init").
+				WithParent(t, init).
+				WithSignatureFromKey(t, []byte(validationtesting.BobPrivateKey), "").
+				Build()
+
+			_, err = testValidationStore.CreateLink(ctx, init2)
+			assert.EqualError(t, err, validators.ErrInvalidTransition.Error())
+		})
+
+		t.Run("invalid signature", func(t *testing.T) {
+			init := chainscripttest.NewLinkBuilder(t).
+				WithProcess("chat").
+				WithStep("init").
+				WithSignatureFromKey(t, []byte(validationtesting.AlicePrivateKey), "").
+				Build()
+
+			_, err := testValidationStore.CreateLink(context.Background(), init)
+			assert.EqualError(t, err, validators.ErrMissingSignature.Error())
+		})
+
+		t.Run("invalid schema", func(t *testing.T) {
+			init := chainscripttest.NewLinkBuilder(t).
+				WithProcess("auction").
+				WithStep("init").
+				WithData(t, map[string]string{
+					"seller": "alice",
+				}).
+				WithSignatureFromKey(t, []byte(validationtesting.AlicePrivateKey), "").
+				Build()
+
+			_, err := testValidationStore.CreateLink(context.Background(), init)
+			assert.EqualError(t, err, validators.ErrInvalidLinkSchema.Error())
+		})
+
+		t.Run("invalid configuration file", func(t *testing.T) {
+			invalidRules := utils.CreateTempFile(t, "validate all the things")
+			defer os.Remove(invalidRules)
+
+			v, err := validation.WrapStoreWithConfigFile(
+				testStore,
+				&validation.Config{RulesPath: invalidRules},
+			)
+
+			assert.Nil(t, v)
+			assert.Error(t, err)
+		})
+
+		t.Run("config file update", func(t *testing.T) {
+			ctx := context.Background()
+			rules := utils.CreateTempFile(t, `{
+				"drivers": {
+				  "steps": {
+					"add": {
+					  "schema": {
+						"type": "object",
+						"properties": {
+						  "name": {
+							"type": "string"
+						  },
+						  "age": {
+							  "type": "string"
+						  }
+						},
+						"required": ["name", "age"]
+					  },
+					}
+				  }
+				}
+			  }`)
+			defer os.Remove(rules)
+
+			v, err := validation.WrapStoreWithConfigFile(
+				testStore,
+				&validation.Config{RulesPath: rules},
+			)
+			require.NoError(t, err)
+			require.NotNil(t, v)
+
+			link := chainscripttest.NewLinkBuilder(t).
+				WithProcess("drivers").
+				WithStep("add").
+				WithData(t, map[string]interface{}{
+					"name": "ryan",
+					"age":  33,
+				}).
+				Build()
+
+			_, err = v.CreateLink(ctx, link)
+			assert.EqualError(t, err, validators.ErrInvalidLinkSchema.Error())
+
+			err = ioutil.WriteFile(rules, []byte(`{
+				"drivers": {
+				  "steps": {
+					"add": {
+					  "schema": {
+						"type": "object",
+						"properties": {
+						  "name": {
+							"type": "string"
+						  },
+						  "age": {
+							  "type": "number"
+						  }
+						},
+						"required": ["name", "age"]
+					  },
+					}
+				  }
+				}
+			  }`), os.ModePerm)
+			require.NoError(t, err)
+
+			_, err = v.CreateLink(ctx, link)
+			assert.NoError(t, err)
+		})
 	})
 }


### PR DESCRIPTION
Adding the first store validation wrapper for non-blockchain stores: a simple filewatch on a configuration file (like what we had before).
Note that if you use store as a library you now need to explicitly wrap your store instance in a validation wrapper otherwise invalid links could be added to your DB.
The next PRs will allow greater customization over what exactly should be validated by which component (store vs validation wrapper).