### PR TITLE
types: add an error struct

### DIFF
--- a/types/error.go
+++ b/types/error.go
@@ -112,15 +112,15 @@ func (e *Error) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':
 		if s.Flag('+') {
-			io.WriteString(s, fmt.Sprintf("error %d: %s", e.Code, e.Message))
+			_, _ = io.WriteString(s, fmt.Sprintf("error %d: %s", e.Code, e.Message))
 			if e.Wrapped != nil {
-				io.WriteString(s, "\n")
-				io.WriteString(s, fmt.Sprintf("%+v", e.Wrapped))
+				_, _ = io.WriteString(s, "\n")
+				_, _ = io.WriteString(s, fmt.Sprintf("%+v", e.Wrapped))
 			}
 			return
 		}
 		fallthrough
 	case 's':
-		io.WriteString(s, e.Error())
+		_, _ = io.WriteString(s, e.Error())
 	}
 }

--- a/types/error.go
+++ b/types/error.go
@@ -114,8 +114,7 @@ func (e *Error) Format(s fmt.State, verb rune) {
 		if s.Flag('+') {
 			_, _ = io.WriteString(s, fmt.Sprintf("error %d: %s", e.Code, e.Message))
 			if e.Wrapped != nil {
-				_, _ = io.WriteString(s, "\n")
-				_, _ = io.WriteString(s, fmt.Sprintf("%+v", e.Wrapped))
+				_, _ = io.WriteString(s, fmt.Sprintf("\n%+v", e.Wrapped))
 			}
 			return
 		}

--- a/types/error.go
+++ b/types/error.go
@@ -1,0 +1,126 @@
+// Copyright 2016-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+// Error structure to provide accurate metrics and logs.
+// Errors coming from external dependencies should always be wrapped inside an
+// instance of this structured error type (in particular to capture a stack
+// trace).
+// Errors coming from dependencies inside go-core should either be propagated
+// as-is or wrapped depending on the code's ability to add new relevant
+// context.
+type Error struct {
+	Code      int    // Error code (see monitoring/errorcode.go).
+	Component string // Component that triggered the error (e.g. "fossilizer").
+	Message   string // Custom error message.
+	Wrapped   error  // Inner error.
+}
+
+// NewError creates a new error and captures a stack trace.
+func NewError(code int, component string, message string) *Error {
+	return &Error{
+		Code:      code,
+		Component: component,
+		Message:   message,
+		Wrapped:   errors.New(""), // this empty error captures a stack trace.
+	}
+}
+
+// NewErrorf creates a new error and captures a stack trace.
+func NewErrorf(code int, component string, format string, args ...interface{}) *Error {
+	return &Error{
+		Code:      code,
+		Component: component,
+		Message:   fmt.Sprintf(format, args...),
+		Wrapped:   errors.New(""), // this empty error captures a stack trace.
+	}
+}
+
+// WrapError wraps an error and adds a stack trace.
+func WrapError(err error, code int, component string, message string) *Error {
+	e := &Error{
+		Code:      code,
+		Component: component,
+		Message:   message,
+	}
+
+	switch err.(type) {
+	case *Error:
+		e.Wrapped = err
+	default:
+		e.Wrapped = errors.WithStack(err)
+	}
+
+	return e
+}
+
+// WrapErrorf wraps an error and adds a stack trace.
+func WrapErrorf(err error, code int, component string, format string, args ...interface{}) *Error {
+	e := &Error{
+		Code:      code,
+		Component: component,
+		Message:   fmt.Sprintf(format, args...),
+	}
+
+	switch err.(type) {
+	case *Error:
+		e.Wrapped = err
+	default:
+		e.Wrapped = errors.WithStack(err)
+	}
+
+	return e
+}
+
+// Error returns a friendly error message.
+func (e *Error) Error() string {
+	if e.Wrapped != nil && e.Wrapped.Error() != "" {
+		return fmt.Sprintf("[%s] error %d: %s: %s", e.Component, e.Code, e.Message, e.Wrapped.Error())
+	}
+
+	return fmt.Sprintf("[%s] error %d: %s", e.Component, e.Code, e.Message)
+}
+
+// String returns a friendly error message.
+func (e *Error) String() string {
+	return e.Error()
+}
+
+// Format the error when printing.
+// %+v prints the full stack trace of the deepest error in the stack in case an
+// internal error was wrapped.
+func (e *Error) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, fmt.Sprintf("error %d: %s", e.Code, e.Message))
+			if e.Wrapped != nil {
+				io.WriteString(s, "\n")
+				io.WriteString(s, fmt.Sprintf("%+v", e.Wrapped))
+			}
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, e.Error())
+	}
+}


### PR DESCRIPTION
This is a proposal to add error code and component name to our errors.
It allows metrics and spans to be tagged by these two values to improve monitoring.
It will also allow the http stores to return accurate http status codes and upstream components to make more accurate decisions when receiving errors.
Let me know what you think before I start updating the error handling in the whole codebase.

Note: I hope that Go 2 will make this struct obsolete :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-core/459)
<!-- Reviewable:end -->
