### PR TITLE
postgres: small improvements

### DIFF
--- a/postgresstore/postgresstore_test.go
+++ b/postgresstore/postgresstore_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stratumn/go-core/store"
 	"github.com/stratumn/go-core/store/storetestcases"
 	"github.com/stratumn/go-core/tmpop/tmpoptestcases"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStore(t *testing.T) {
@@ -84,4 +85,13 @@ func createAdapterTMPop() (store.Adapter, store.KeyValueStore, error) {
 
 func freeAdapterTMPop(a store.Adapter, _ store.KeyValueStore) {
 	freeAdapter(a)
+}
+
+func TestCreatePrepare(t *testing.T) {
+	// If create and prepare have already been called, we should not fail.
+	_, err := createStore()
+	require.NoError(t, err)
+
+	_, err = createStore()
+	require.NoError(t, err)
 }

--- a/postgresstore/stmts.go
+++ b/postgresstore/stmts.go
@@ -109,7 +109,7 @@ var sqlCreate = []string{
 	`
 		CREATE TABLE IF NOT EXISTS store.links (
 			id BIGSERIAL PRIMARY KEY,
-			link_hash bytea NOT NULL,
+			link_hash bytea NOT NULL UNIQUE,
 			priority double precision NOT NULL,
 			map_id text NOT NULL,
 			prev_link_hash bytea DEFAULT NULL,
@@ -120,10 +120,6 @@ var sqlCreate = []string{
 			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)
-	`,
-	`
-		CREATE UNIQUE INDEX IF NOT EXISTS links_link_hash_idx
-		ON store.links (link_hash)
 	`,
 	`
 		CREATE INDEX IF NOT EXISTS links_priority_created_at_idx
@@ -148,13 +144,9 @@ var sqlCreate = []string{
 	`
 		CREATE TABLE IF NOT EXISTS store_private.links_degree (
 			id BIGSERIAL PRIMARY KEY,
-			link_hash bytea references store.links(link_hash),
+			link_hash bytea references store.links(link_hash) UNIQUE,
 			out_degree integer
 		)
-	`,
-	`
-		CREATE UNIQUE INDEX IF NOT EXISTS links_degree_link_hash_idx
-		ON store_private.links_degree (link_hash)
 	`,
 	`
 		CREATE TABLE IF NOT EXISTS store.evidences (
@@ -163,12 +155,9 @@ var sqlCreate = []string{
 			provider text NOT NULL,
 			data bytea NOT NULL,
 			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(link_hash, provider)
 		)
-	`,
-	`
-		CREATE UNIQUE INDEX IF NOT EXISTS evidences_link_hash_provider_idx
-		ON store.evidences (link_hash, provider)
 	`,
 	`
 		CREATE INDEX IF NOT EXISTS evidences_link_hash_idx
@@ -177,27 +166,20 @@ var sqlCreate = []string{
 	`
 		CREATE TABLE IF NOT EXISTS store.values (
 			id BIGSERIAL PRIMARY KEY,
-			key bytea NOT NULL,
+			key bytea NOT NULL UNIQUE,
 			value bytea NOT NULL,
 			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)
 	`,
 	`
-		CREATE UNIQUE INDEX IF NOT EXISTS values_key_idx
-		ON store.values (key)
-	`,
-	`
 		CREATE TABLE IF NOT EXISTS store_private.process_maps (
 			id BIGSERIAL PRIMARY KEY,
 			process text NOT NULL,
 			map_id text NOT NULL,
-			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(process, map_id)
 		)
-	`,
-	`
-		CREATE UNIQUE INDEX IF NOT EXISTS process_map_idx
-		ON store_private.process_maps (process, map_id)
 	`,
 }
 


### PR DESCRIPTION
Declare unique constraints directly inside the `create table` statements.
I also wanted to have prevlinkhash directly reference linkhash (to prevent inserting segments with invalid parents) but it's impossible because we allow prevlinkhash to be null.
Added a small test to prevent the error we encountered when creation failed because schema/tables were already there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-core/466)
<!-- Reviewable:end -->
