### PR TITLE
jsonhttp: enable cors

### DIFF
--- a/jsonhttp/jsonhttp.go
+++ b/jsonhttp/jsonhttp.go
@@ -155,6 +155,11 @@ type handler struct {
 func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	var err error
 
+	// Enable CORS, no restriction.
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
+	w.Header().Set("Access-Control-Allow-Headers", "Accept, Accept-Language, Authorization, Content-Type")
+
 	data, err := h.serve(w, r, p)
 	if err != nil {
 		renderErr(w, r, err)

--- a/jsonhttp/jsonhttp_test.go
+++ b/jsonhttp/jsonhttp_test.go
@@ -89,6 +89,7 @@ func TestOptions(t *testing.T) {
 	w, err := testutil.RequestJSON(s.ServeHTTP, "OPTIONS", "/test", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, `{"test":true}`, w.Body.String())
+	assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
 }
 
 func TestNotFound(t *testing.T) {


### PR DESCRIPTION
There's not reason to leverage CORS protection for our store and fossilizer APIs.
We want frontend apps to be able to directly call a store or a fossilizer if needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-core/474)
<!-- Reviewable:end -->
