### PR TITLE
jsonhttp: config enable CORS

### DIFF
--- a/fossilizer/fossilizerhttp/cmd.go
+++ b/fossilizer/fossilizerhttp/cmd.go
@@ -47,6 +47,7 @@ var (
 	writeTimeout            time.Duration
 	maxHeaderBytes          int
 	shutdownTimeout         time.Duration
+	enableCORS              bool
 )
 
 // Run launches a fossilizerhttp server.
@@ -103,6 +104,7 @@ func RegisterFlags() {
 	flag.DurationVar(&wsPongTimeout, "ws_pong_timeout", jsonws.DefaultWebSocketPongTimeout, "Timeout for a web socket expected pong")
 	flag.DurationVar(&wsPingInterval, "ws_ping_interval", jsonws.DefaultWebSocketPingInterval, "Interval between web socket pings")
 	flag.Int64Var(&wsMaxMsgSize, "max_msg_size", jsonws.DefaultWebSocketMaxMsgSize, "Maximum size of a received web socket message")
+	flag.BoolVar(&enableCORS, "enable_cors", false, "Allow cross-origin requests")
 }
 
 // RunWithFlags should be called after RegisterFlags and flag.Parse to launch
@@ -121,6 +123,7 @@ func RunWithFlags(ctx context.Context, a fossilizer.Adapter) {
 		MaxHeaderBytes: maxHeaderBytes,
 		CertFile:       certFile,
 		KeyFile:        keyFile,
+		EnableCORS:     enableCORS,
 	}
 	basicConfig := &jsonws.BasicConfig{
 		ReadBufferSize:  wsReadBufSize,

--- a/jsonhttp/jsonhttp_test.go
+++ b/jsonhttp/jsonhttp_test.go
@@ -89,6 +89,19 @@ func TestOptions(t *testing.T) {
 	w, err := testutil.RequestJSON(s.ServeHTTP, "OPTIONS", "/test", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, `{"test":true}`, w.Body.String())
+}
+
+func TestCORS(t *testing.T) {
+	s := New(&Config{EnableCORS: true})
+	// Once CORS is enabled, options calls are automatically handled on all
+	// registered routes.
+	s.Get("/test", func(r http.ResponseWriter, _ *http.Request, p httprouter.Params) (interface{}, error) {
+		return map[string]bool{"test": true}, nil
+	})
+
+	w, err := testutil.RequestJSON(s.ServeHTTP, "OPTIONS", "/test", nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
 }
 

--- a/store/storehttp/cmd.go
+++ b/store/storehttp/cmd.go
@@ -47,6 +47,7 @@ var (
 	writeTimeout        time.Duration
 	maxHeaderBytes      int
 	shutdownTimeout     time.Duration
+	enableCORS          bool
 )
 
 // Run launches a storehttp server.
@@ -106,6 +107,7 @@ func RegisterFlags() {
 	flag.DurationVar(&writeTimeout, "write_timeout", jsonhttp.DefaultWriteTimeout, "Write timeout")
 	flag.IntVar(&maxHeaderBytes, "max_header_bytes", jsonhttp.DefaultMaxHeaderBytes, "Maximum header bytes")
 	flag.DurationVar(&shutdownTimeout, "shutdown_timeout", 10*time.Second, "Shutdown timeout")
+	flag.BoolVar(&enableCORS, "enable_cors", false, "Allow cross-origin requests")
 }
 
 // RunWithFlags should be called after RegisterFlags and flag.Parse to launch
@@ -122,6 +124,7 @@ func RunWithFlags(a store.Adapter) {
 		MaxHeaderBytes: maxHeaderBytes,
 		CertFile:       certFile,
 		KeyFile:        keyFile,
+		EnableCORS:     enableCORS,
 	}
 	basicConfig := &jsonws.BasicConfig{
 		ReadBufferSize:  wsReadBufSize,


### PR DESCRIPTION
CORS requires options calls to be handled on all routes, so I think that the easiest way is to automatically add an OPTIONS handler on all defined routes when CORS is enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-core/476)
<!-- Reviewable:end -->
