### PR TITLE
validation: governance participants

### DIFF
--- a/validation/validators/governance.go
+++ b/validation/validators/governance.go
@@ -1,0 +1,22 @@
+// Copyright 2016-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validators
+
+const (
+	// GovernanceProcess is the name of the process containing validation rules
+	// in a decentralized network.
+	// Special rules apply to segments inside this process.
+	GovernanceProcess = "_governance"
+)

--- a/validation/validators/participant.go
+++ b/validation/validators/participant.go
@@ -1,0 +1,51 @@
+// Copyright 2016-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validators
+
+import (
+	"github.com/pkg/errors"
+)
+
+// Participant errors.
+var (
+	ErrInvalidVotingPower     = errors.New("participant voting power is missing")
+	ErrMissingParticipantName = errors.New("participant name is missing")
+	ErrMissingParticipantKey  = errors.New("participant public key is missing")
+)
+
+// Participant in a decentralized network.
+// Participants have the responsibility of voting for validation rules updates.
+type Participant struct {
+	Name      string `json:"name"`
+	Power     uint   `json:"votingPower"`
+	PublicKey []byte `json:"publicKey"`
+}
+
+// Validate participant data.
+func (p Participant) Validate() error {
+	if p.Power == 0 {
+		return ErrInvalidVotingPower
+	}
+
+	if len(p.Name) == 0 {
+		return ErrMissingParticipantName
+	}
+
+	if len(p.PublicKey) == 0 {
+		return ErrMissingParticipantKey
+	}
+
+	return nil
+}

--- a/validation/validators/participant_test.go
+++ b/validation/validators/participant_test.go
@@ -1,0 +1,68 @@
+// Copyright 2016-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validators_test
+
+import (
+	"testing"
+
+	"github.com/stratumn/go-core/validation/validationtesting"
+	"github.com/stratumn/go-core/validation/validators"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParticipant(t *testing.T) {
+	t.Run("Validate()", func(t *testing.T) {
+		t.Run("missing name", func(t *testing.T) {
+			p := &validators.Participant{
+				Power:     3,
+				PublicKey: []byte(validationtesting.AlicePublicKey),
+			}
+
+			err := p.Validate()
+			assert.EqualError(t, err, validators.ErrMissingParticipantName.Error())
+		})
+
+		t.Run("missing public key", func(t *testing.T) {
+			p := &validators.Participant{
+				Name:  "alice",
+				Power: 3,
+			}
+
+			err := p.Validate()
+			assert.EqualError(t, err, validators.ErrMissingParticipantKey.Error())
+		})
+
+		t.Run("missing voting power", func(t *testing.T) {
+			p := &validators.Participant{
+				Name:      "alice",
+				PublicKey: []byte(validationtesting.AlicePublicKey),
+			}
+
+			err := p.Validate()
+			assert.EqualError(t, err, validators.ErrInvalidVotingPower.Error())
+		})
+
+		t.Run("valid participant", func(t *testing.T) {
+			p := &validators.Participant{
+				Name:      "alice",
+				Power:     3,
+				PublicKey: []byte(validationtesting.AlicePublicKey),
+			}
+
+			err := p.Validate()
+			assert.NoError(t, err)
+		})
+	})
+}

--- a/validation/validators/participants.go
+++ b/validation/validators/participants.go
@@ -1,0 +1,55 @@
+// Copyright 2016-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validators
+
+import (
+	"context"
+
+	"github.com/stratumn/go-chainscript"
+	"github.com/stratumn/go-core/store"
+)
+
+const (
+	// ParticipantsValidatorName name for monitoring.
+	ParticipantsValidatorName = "participants-validator"
+)
+
+// ParticipantsValidator validates changes to the governance participants list.
+type ParticipantsValidator struct{}
+
+// NewParticipantsValidator creates a new participants validator for the
+// network.
+// A participants validator is needed for decentralized networks that leverage
+// governance to update processes' validation rules.
+func NewParticipantsValidator() Validator {
+	return &ParticipantsValidator{}
+}
+
+// Validate a participants update.
+func (v *ParticipantsValidator) Validate(context.Context, store.SegmentReader, *chainscript.Link) error {
+	panic("not implemented")
+}
+
+// ShouldValidate returns true if the segment belongs to the participants map
+// in the governance process.
+func (v *ParticipantsValidator) ShouldValidate(*chainscript.Link) bool {
+	panic("not implemented")
+}
+
+// Hash returns an empty hash since ParticipantsValidator doesn't have any
+// configuration (it works the same for every decentralized network).
+func (v *ParticipantsValidator) Hash() ([]byte, error) {
+	return nil, nil
+}

--- a/validation/validators/participants.go
+++ b/validation/validators/participants.go
@@ -17,8 +17,11 @@ package validators
 import (
 	"context"
 
+	"github.com/pkg/errors"
 	"github.com/stratumn/go-chainscript"
+	"github.com/stratumn/go-core/monitoring/errorcode"
 	"github.com/stratumn/go-core/store"
+	"github.com/stratumn/go-core/types"
 )
 
 const (
@@ -28,6 +31,18 @@ const (
 	// ParticipantsMap is the ID of the map containing participants in the
 	// governance process.
 	ParticipantsMap = "_participants"
+)
+
+// Allowed steps in the participants map.
+const (
+	ParticipantsAcceptStep = "accept"
+	ParticipantsUpdateStep = "update"
+	ParticipantsVoteStep   = "vote"
+)
+
+// Errors used by the participants validator.
+var (
+	ErrInvalidParticipantStep = errors.New("invalid step in network participants update")
 )
 
 // ParticipantsValidator validates changes to the governance participants list.
@@ -42,8 +57,17 @@ func NewParticipantsValidator() Validator {
 }
 
 // Validate a participants update.
-func (v *ParticipantsValidator) Validate(context.Context, store.SegmentReader, *chainscript.Link) error {
-	panic("not implemented")
+func (v *ParticipantsValidator) Validate(ctx context.Context, r store.SegmentReader, l *chainscript.Link) error {
+	switch l.Meta.Step {
+	case ParticipantsAcceptStep:
+		panic("not implemented")
+	case ParticipantsUpdateStep:
+		panic("not implemented")
+	case ParticipantsVoteStep:
+		panic("not implemented")
+	default:
+		return types.WrapError(ErrInvalidParticipantStep, errorcode.InvalidArgument, ParticipantsValidatorName, "participants validation failed")
+	}
 }
 
 // ShouldValidate returns true if the segment belongs to the participants map

--- a/validation/validators/participants.go
+++ b/validation/validators/participants.go
@@ -24,6 +24,10 @@ import (
 const (
 	// ParticipantsValidatorName name for monitoring.
 	ParticipantsValidatorName = "participants-validator"
+
+	// ParticipantsMap is the ID of the map containing participants in the
+	// governance process.
+	ParticipantsMap = "_participants"
 )
 
 // ParticipantsValidator validates changes to the governance participants list.
@@ -44,8 +48,8 @@ func (v *ParticipantsValidator) Validate(context.Context, store.SegmentReader, *
 
 // ShouldValidate returns true if the segment belongs to the participants map
 // in the governance process.
-func (v *ParticipantsValidator) ShouldValidate(*chainscript.Link) bool {
-	panic("not implemented")
+func (v *ParticipantsValidator) ShouldValidate(l *chainscript.Link) bool {
+	return l.Meta.Process.Name == GovernanceProcess && l.Meta.MapId == ParticipantsMap
 }
 
 // Hash returns an empty hash since ParticipantsValidator doesn't have any

--- a/validation/validators/participants_test.go
+++ b/validation/validators/participants_test.go
@@ -1,0 +1,32 @@
+// Copyright 2016-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validators_test
+
+import (
+	"testing"
+
+	"github.com/stratumn/go-core/validation/validators"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParticipantsValidator(t *testing.T) {
+	t.Run("Hash()", func(t *testing.T) {
+		v := validators.NewParticipantsValidator()
+		h, err := v.Hash()
+		require.NoError(t, err)
+		assert.Nil(t, h)
+	})
+}

--- a/validation/validators/participants_test.go
+++ b/validation/validators/participants_test.go
@@ -17,14 +17,42 @@ package validators_test
 import (
 	"testing"
 
+	"github.com/stratumn/go-chainscript/chainscripttest"
 	"github.com/stratumn/go-core/validation/validators"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParticipantsValidator(t *testing.T) {
+	v := validators.NewParticipantsValidator()
+
+	t.Run("ShouldValidate()", func(t *testing.T) {
+		t.Run("ignores non-governance process", func(t *testing.T) {
+			l := chainscripttest.NewLinkBuilder(t).
+				WithProcess("not-governance").
+				WithMapID(validators.ParticipantsMap).
+				Build()
+			assert.False(t, v.ShouldValidate(l))
+		})
+
+		t.Run("ignores non-participants map", func(t *testing.T) {
+			l := chainscripttest.NewLinkBuilder(t).
+				WithProcess(validators.GovernanceProcess).
+				WithMapID("not-participants").
+				Build()
+			assert.False(t, v.ShouldValidate(l))
+		})
+
+		t.Run("validates governance participants", func(t *testing.T) {
+			l := chainscripttest.NewLinkBuilder(t).
+				WithProcess(validators.GovernanceProcess).
+				WithMapID(validators.ParticipantsMap).
+				Build()
+			assert.True(t, v.ShouldValidate(l))
+		})
+	})
+
 	t.Run("Hash()", func(t *testing.T) {
-		v := validators.NewParticipantsValidator()
 		h, err := v.Hash()
 		require.NoError(t, err)
 		assert.Nil(t, h)

--- a/validation/validators/participants_test.go
+++ b/validation/validators/participants_test.go
@@ -15,9 +15,11 @@
 package validators_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stratumn/go-chainscript/chainscripttest"
+	"github.com/stratumn/go-core/testutil"
 	"github.com/stratumn/go-core/validation/validators"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,6 +27,18 @@ import (
 
 func TestParticipantsValidator(t *testing.T) {
 	v := validators.NewParticipantsValidator()
+
+	t.Run("Validate()", func(t *testing.T) {
+		t.Run("rejects unknown step", func(t *testing.T) {
+			l := chainscripttest.NewLinkBuilder(t).
+				WithProcess(validators.GovernanceProcess).
+				WithMapID(validators.ParticipantsMap).
+				WithStep("pwn").
+				Build()
+			err := v.Validate(context.Background(), nil, l)
+			testutil.AssertWrappedErrorEqual(t, err, validators.ErrInvalidParticipantStep)
+		})
+	})
 
 	t.Run("ShouldValidate()", func(t *testing.T) {
 		t.Run("ignores non-governance process", func(t *testing.T) {


### PR DESCRIPTION
Start implementing the validators required for governance in decentralized networks.
The first element needed is a special map in the validator process to track the network's participants (because we'll need this participants' list to be able to vote for validation rules updates in next PRs).

The participants map only accepts three types of links:

- `accept`: contains the latest list of participants with their voting power. Can have only one children. This is what other maps will reference to know what participants are currently in the network and should vote.
- `update`: propose a participants list update
- `vote`: vote for a participants list update

In this PR I only implement the ability to create the first `accept` link in the map. `update`, `vote` and non-initial `accept` link support will be for the next PRs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-core/485)
<!-- Reviewable:end -->
