### PR TITLE
fossilizer: aws queue

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -41,19 +41,20 @@ blocks:
     task:
       secrets:
         - name: go-core-codecov
+        - name: aws-deploy
       prologue:
         commands_file: boilerplate
       jobs:
-      - name: Headers
-        commands:
-          - make test_headers
-      - name: Lint
-        commands:
-          - make lint
-      - name: Test
-        commands:
-          - make coverage
-          - bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN
+        - name: Headers
+          commands:
+            - make test_headers
+        - name: Lint
+          commands:
+            - make lint
+        - name: Test
+          commands:
+            - make coverage
+            - bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN
 
 promotions:
   - name: Publish to DockerHub

--- a/batchfossilizer/cmd.go
+++ b/batchfossilizer/cmd.go
@@ -26,7 +26,7 @@ var (
 	maxSimBatches int
 )
 
-// RegisterFlags registers the flags used by RunWithFlags.
+// RegisterFlags registers the flags used by batch fossilizers.
 func RegisterFlags() {
 	flag.DurationVar(&interval, "interval", DefaultInterval, "batch interval")
 	flag.IntVar(&maxLeaves, "maxleaves", DefaultMaxLeaves, "maximum number of leaves in a Merkle tree")

--- a/cloud/aws/cmd.go
+++ b/cloud/aws/cmd.go
@@ -1,0 +1,42 @@
+// Copyright 2016-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"flag"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	log "github.com/sirupsen/logrus"
+)
+
+// Flags variables.
+var (
+	region string
+)
+
+// RegisterFlags registers the flags used by AWS components.
+func RegisterFlags() {
+	flag.StringVar(&region, "awsregion", "", "AWS region")
+}
+
+// SessionFromFlags returns an AWS session from command-line flags.
+func SessionFromFlags() *session.Session {
+	sess, err := NewSession(region)
+	if err != nil {
+		log.WithField("error", err.Error()).Fatal("could not create AWS session")
+	}
+
+	return sess
+}

--- a/cloud/aws/doc.go
+++ b/cloud/aws/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2016-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package aws contains utilites for Amazon Web Services.
+package aws

--- a/cloud/aws/queue.go
+++ b/cloud/aws/queue.go
@@ -1,0 +1,39 @@
+// Copyright 2016-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"context"
+
+	"github.com/stratumn/go-core/fossilizer"
+)
+
+// FossilsQueue implements a fossils queue backed by AWS SQS.
+type FossilsQueue struct{}
+
+// NewFossilsQueue blablabla
+func NewFossilsQueue() fossilizer.FossilsQueue {
+	return &FossilsQueue{}
+}
+
+// Push a fossil to the queue.
+func (q *FossilsQueue) Push(context.Context, *fossilizer.Fossil) error {
+	return nil
+}
+
+// Pop fossils from the queue.
+func (q *FossilsQueue) Pop(context.Context, int) ([]*fossilizer.Fossil, error) {
+	return nil, nil
+}

--- a/cloud/aws/queue.go
+++ b/cloud/aws/queue.go
@@ -16,24 +16,135 @@ package aws
 
 import (
 	"context"
+	"encoding/json"
 
+	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/stratumn/go-core/fossilizer"
+	"github.com/stratumn/go-core/monitoring"
+	"github.com/stratumn/go-core/monitoring/errorcode"
+	"github.com/stratumn/go-core/types"
+
+	"go.opencensus.io/trace"
+)
+
+const (
+	// AWS documentation states that batches can be at most 10 messages.
+	batchSize = 10
+
+	// QueueComponent name for monitoring.
+	QueueComponent = "FossilsQueue"
 )
 
 // FossilsQueue implements a fossils queue backed by AWS SQS.
-type FossilsQueue struct{}
+type FossilsQueue struct {
+	client   *sqs.SQS
+	queueURL *string
+}
 
-// NewFossilsQueue blablabla
-func NewFossilsQueue() fossilizer.FossilsQueue {
-	return &FossilsQueue{}
+// NewFossilsQueue connects to the given AWS SQS queue.
+func NewFossilsQueue(client *sqs.SQS, queueURL *string) fossilizer.FossilsQueue {
+	return &FossilsQueue{
+		client:   client,
+		queueURL: queueURL,
+	}
 }
 
 // Push a fossil to the queue.
-func (q *FossilsQueue) Push(context.Context, *fossilizer.Fossil) error {
+func (q *FossilsQueue) Push(ctx context.Context, f *fossilizer.Fossil) (err error) {
+	_, span := trace.StartSpan(ctx, "cloud/aws/queue/push")
+	defer func() {
+		monitoring.SetSpanStatusAndEnd(span, err)
+	}()
+
+	jsonFossil, err := json.Marshal(f)
+	if err != nil {
+		return types.WrapError(err, errorcode.InvalidArgument, QueueComponent, "json.Marshal")
+	}
+
+	body := string(jsonFossil)
+
+	_, err = q.client.SendMessage(&sqs.SendMessageInput{
+		QueueUrl:    q.queueURL,
+		MessageBody: &body,
+	})
+	if err != nil {
+		return types.WrapError(err, errorcode.Unknown, QueueComponent, "error sending message to AWS SQS")
+	}
+
 	return nil
 }
 
 // Pop fossils from the queue.
-func (q *FossilsQueue) Pop(context.Context, int) ([]*fossilizer.Fossil, error) {
-	return nil, nil
+func (q *FossilsQueue) Pop(ctx context.Context, count int) ([]*fossilizer.Fossil, error) {
+	ctx, span := trace.StartSpan(ctx, "cloud/aws/queue/pop")
+	defer span.End()
+
+	var results []*fossilizer.Fossil
+	for {
+		nextBatchSize := batchSize
+		if (count - len(results)) < nextBatchSize {
+			nextBatchSize = count - len(results)
+		}
+
+		fossils, err := q.pop(ctx, int64(nextBatchSize))
+		if err != nil {
+			monitoring.SetSpanStatus(span, err)
+			return nil, err
+		}
+
+		results = append(results, fossils...)
+
+		// If the queue is empty, stop.
+		if len(fossils) == 0 {
+			return results, nil
+		}
+
+		// If we have the request count, stop.
+		if len(results) == count {
+			return results, nil
+		}
+	}
+}
+
+// pop a small number of elements (in the limits allowed by AWS).
+func (q *FossilsQueue) pop(ctx context.Context, count int64) ([]*fossilizer.Fossil, error) {
+	var fossils []*fossilizer.Fossil
+	var entries []*sqs.DeleteMessageBatchRequestEntry
+
+	r, err := q.client.ReceiveMessage(&sqs.ReceiveMessageInput{
+		MaxNumberOfMessages: &count,
+		QueueUrl:            q.queueURL,
+	})
+	if err != nil {
+		return nil, types.WrapError(err, errorcode.Unknown, QueueComponent, "error receiving message from AWS SQS")
+	}
+
+	// The queue is empty.
+	if len(r.Messages) == 0 {
+		return nil, nil
+	}
+
+	for _, m := range r.Messages {
+		var fossil fossilizer.Fossil
+		err := json.Unmarshal([]byte(*m.Body), &fossil)
+		if err != nil {
+			return nil, types.WrapError(err, errorcode.InvalidArgument, QueueComponent, "json.Unmarshal")
+		}
+
+		fossils = append(fossils, &fossil)
+		entries = append(entries, &sqs.DeleteMessageBatchRequestEntry{
+			Id:            m.MessageId,
+			ReceiptHandle: m.ReceiptHandle,
+		})
+	}
+
+	_, err = q.client.DeleteMessageBatch(&sqs.DeleteMessageBatchInput{
+		QueueUrl: q.queueURL,
+		Entries:  entries,
+	})
+	if err != nil {
+		return nil, types.WrapError(err, errorcode.Unknown, QueueComponent, "error deleting message from AWS SQS")
+	}
+
+	return fossils, nil
 }

--- a/cloud/aws/queue_test.go
+++ b/cloud/aws/queue_test.go
@@ -1,0 +1,15 @@
+// Copyright 2016-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws_test

--- a/cloud/aws/queue_test.go
+++ b/cloud/aws/queue_test.go
@@ -39,8 +39,12 @@ const (
 func TestFossilsQueue(t *testing.T) {
 	cfg := aws.NewConfig().
 		WithRegion(testRegion).
-		// You need valid credentials in the ~/.aws folder.
-		WithCredentials(credentials.NewSharedCredentials("", "default"))
+		// You need valid credentials in the ~/.aws folder or in your
+		// environment variables.
+		WithCredentials(credentials.NewChainCredentials([]credentials.Provider{
+			&credentials.EnvProvider{},
+			&credentials.SharedCredentialsProvider{},
+		}))
 
 	sess, err := session.NewSession(cfg)
 	require.NoError(t, err)
@@ -49,6 +53,8 @@ func TestFossilsQueue(t *testing.T) {
 	defer cleanTestQueues(t, client)
 
 	t.Run("push and pop", func(t *testing.T) {
+		t.Parallel()
+
 		ctx := context.Background()
 		queueURL := createTestQueue(t, client)
 		q := awsqueue.NewFossilsQueue(client, queueURL)
@@ -74,6 +80,8 @@ func TestFossilsQueue(t *testing.T) {
 	})
 
 	t.Run("pop empty queue", func(t *testing.T) {
+		t.Parallel()
+
 		ctx := context.Background()
 		queueURL := createTestQueue(t, client)
 		q := awsqueue.NewFossilsQueue(client, queueURL)
@@ -84,6 +92,8 @@ func TestFossilsQueue(t *testing.T) {
 	})
 
 	t.Run("pop many", func(t *testing.T) {
+		t.Parallel()
+
 		ctx := context.Background()
 		queueURL := createTestQueue(t, client)
 		q := awsqueue.NewFossilsQueue(client, queueURL)
@@ -108,6 +118,8 @@ func TestFossilsQueue(t *testing.T) {
 	})
 
 	t.Run("pop more than queue size", func(t *testing.T) {
+		t.Parallel()
+
 		ctx := context.Background()
 		queueURL := createTestQueue(t, client)
 		q := awsqueue.NewFossilsQueue(client, queueURL)

--- a/cloud/aws/queue_test.go
+++ b/cloud/aws/queue_test.go
@@ -21,9 +21,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	awsqueue "github.com/stratumn/go-core/cloud/aws"
 	"github.com/stratumn/go-core/fossilizer"
@@ -37,16 +34,7 @@ const (
 )
 
 func TestFossilsQueue(t *testing.T) {
-	cfg := aws.NewConfig().
-		WithRegion(testRegion).
-		// You need valid credentials in the ~/.aws folder or in your
-		// environment variables.
-		WithCredentials(credentials.NewChainCredentials([]credentials.Provider{
-			&credentials.EnvProvider{},
-			&credentials.SharedCredentialsProvider{},
-		}))
-
-	sess, err := session.NewSession(cfg)
+	sess, err := awsqueue.NewSession(testRegion)
 	require.NoError(t, err)
 
 	client := sqs.New(sess)

--- a/cloud/aws/session.go
+++ b/cloud/aws/session.go
@@ -1,0 +1,35 @@
+// Copyright 2016-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+)
+
+// NewSession creates a new session in the given AWS region.
+// You need valid credentials in the ~/.aws folder or in your environment
+// variables.
+func NewSession(region string) (*session.Session, error) {
+	cfg := aws.NewConfig().
+		WithRegion(region).
+		WithCredentials(credentials.NewChainCredentials([]credentials.Provider{
+			&credentials.EnvProvider{},
+			&credentials.SharedCredentialsProvider{},
+		}))
+
+	return session.NewSession(cfg)
+}

--- a/cloud/doc.go
+++ b/cloud/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2016-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cloud contains utilites for cloud services providers.
+package cloud

--- a/cmd/btcfossilizer/main.go
+++ b/cmd/btcfossilizer/main.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stratumn/go-core/blockchain/btc/blockcypher"
 	"github.com/stratumn/go-core/blockchain/btc/btctimestamper"
 	"github.com/stratumn/go-core/blockchainfossilizer"
-	"github.com/stratumn/go-core/fossilizer/dummyqueue"
+	"github.com/stratumn/go-core/cloud/aws"
 	"github.com/stratumn/go-core/fossilizer/fossilizerhttp"
 	"github.com/stratumn/go-core/monitoring"
 	"github.com/stratumn/go-core/util"
@@ -36,6 +36,9 @@ var (
 	bcyAPIKey = flag.String("bcyapikey", "", "BlockCypher API key")
 	fee       = flag.Int64("fee", int64(15000), "transaction fee (satoshis)")
 
+	queueType    = flag.String("queuetype", AWSQueue, "queue implementation ('dummy' or 'aws')")
+	fossilsQueue = flag.String("fossilsqueue", DefaultFossilsQueue, "name of the pending fossils queue")
+
 	version = "x.x.x"
 	commit  = "00000000000000000000000000000000"
 )
@@ -44,6 +47,7 @@ func init() {
 	fossilizerhttp.RegisterFlags()
 	batchfossilizer.RegisterFlags()
 	monitoring.RegisterFlags()
+	aws.RegisterFlags()
 }
 
 func main() {
@@ -83,7 +87,7 @@ func main() {
 				Version:     version,
 				Timestamper: ts,
 			}),
-			dummyqueue.New(), // TODO: plug configurable queue implementation
+			QueueFromFlags(),
 		),
 		"btcfossilizer",
 	)

--- a/cmd/btcfossilizer/queue.go
+++ b/cmd/btcfossilizer/queue.go
@@ -1,0 +1,60 @@
+// Copyright 2016-2018 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/aws/aws-sdk-go/service/sqs"
+	log "github.com/sirupsen/logrus"
+	"github.com/stratumn/go-core/cloud/aws"
+	"github.com/stratumn/go-core/fossilizer"
+	"github.com/stratumn/go-core/fossilizer/dummyqueue"
+)
+
+// Queues that can be used by the BTC fossilizer.
+const (
+	DummyQueue = "dummy"
+	AWSQueue   = "aws"
+)
+
+// Default values for command-line flags.
+const (
+	DefaultFossilsQueue = "pending-fossils"
+)
+
+// QueueFromFlags creates a fossils queue from command-line flags.
+func QueueFromFlags() fossilizer.FossilsQueue {
+	switch *queueType {
+	case DummyQueue:
+		return dummyqueue.New()
+	case AWSQueue:
+		session := aws.SessionFromFlags()
+		client := sqs.New(session)
+		queueURL := QueueURL(client, fossilsQueue)
+		return aws.NewFossilsQueue(client, queueURL)
+	default:
+		log.WithField("queueType", queueType).Fatal("unknown queue type")
+		return nil
+	}
+}
+
+// QueueURL retrieves the queue URL from its name.
+func QueueURL(client *sqs.SQS, queueName *string) *string {
+	r, err := client.GetQueueUrl(&sqs.GetQueueUrlInput{QueueName: queueName})
+	if err != nil {
+		log.WithField("error", err.Error()).Fatal("aws configuration is invalid")
+	}
+
+	return r.QueueUrl
+}

--- a/fossilizer/fossilizer.go
+++ b/fossilizer/fossilizer.go
@@ -37,10 +37,10 @@ type Adapter interface {
 // Fossil that will be fossilized.
 type Fossil struct {
 	// The data that was fossilized.
-	Data []byte
+	Data []byte `json:"data"`
 
 	// The metadata associated with the fossilized data.
-	Meta []byte
+	Meta []byte `json:"meta"`
 }
 
 // Result is the type sent to the result channels.


### PR DESCRIPTION
FossilsQueue leveraging AWS SQS.
Add command-line arguments to setup AWS queue for the BTC fossilizer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-core/498)
<!-- Reviewable:end -->
