### PR TITLE
btc: add metric that reports account balance

### DIFF
--- a/blockchain/btc/blockcypher/blockcypher.go
+++ b/blockchain/btc/blockcypher/blockcypher.go
@@ -99,6 +99,8 @@ func (c *Client) FindUnspent(ctx context.Context, address *types.ReversedBytes20
 	}
 
 	res.Total = int64(addrInfo.Balance)
+	ctx, _ = tag.New(ctx, tag.Upsert(accountAddress, addr))
+	stats.Record(ctx, accountBalance.M(res.Total))
 
 	for _, TXRef := range addrInfo.TXRefs {
 		output := btc.Output{Index: TXRef.TXOutputN}

--- a/blockchain/btc/blockcypher/metrics.go
+++ b/blockchain/btc/blockcypher/metrics.go
@@ -29,6 +29,9 @@ var (
 	requestCount   *stats.Int64Measure
 	requestErr     *stats.Int64Measure
 	requestLatency *stats.Float64Measure
+
+	accountAddress tag.Key
+	accountBalance *stats.Int64Measure
 )
 
 func init() {
@@ -50,8 +53,17 @@ func init() {
 		stats.UnitMilliseconds,
 	)
 
+	accountBalance = stats.Int64(
+		"stratumn/core/blockchain/btc/account_balance",
+		"balance of the bitcoin addresses used",
+		stats.UnitDimensionless,
+	)
+
 	var err error
 	if requestType, err = tag.NewKey("stratumn/core/blockchain/btc/request_type"); err != nil {
+		log.Fatal(err)
+	}
+	if accountAddress, err = tag.NewKey("stratumn/core/blockchain/btc/address"); err != nil {
 		log.Fatal(err)
 	}
 
@@ -76,6 +88,13 @@ func init() {
 			Measure:     requestLatency,
 			Aggregation: monitoring.DefaultLatencyDistribution,
 			TagKeys:     []tag.Key{requestType},
+		},
+		&view.View{
+			Name:        "stratumn/core/blockchain/btc/account_balance",
+			Description: "balance of the bitcoin addresses used",
+			Measure:     accountBalance,
+			Aggregation: view.LastValue(),
+			TagKeys:     []tag.Key{accountAddress},
 		})
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
We can then easily alert on that metric when the fossilizer's balance is getting low.
It will prevent us from being unable to fossilize important data (we'll need to send more btc to the fossilizer address which isn't automated yet though).

Resolves #500 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-core/501)
<!-- Reviewable:end -->
