### PR TITLE
batchfossilizer: push failed fossils back to the queue (fixes #505).

### DIFF
--- a/fossilizer/dummyqueue/queue.go
+++ b/fossilizer/dummyqueue/queue.go
@@ -25,6 +25,8 @@ import (
 type DummyQueue struct {
 	fossilsLock sync.RWMutex
 	fossils     []*fossilizer.Fossil
+	popCount    int
+	pushCount   int
 }
 
 // New creates a new dummy queue.
@@ -38,7 +40,17 @@ func (q *DummyQueue) Push(_ context.Context, f *fossilizer.Fossil) error {
 	defer q.fossilsLock.Unlock()
 
 	q.fossils = append(q.fossils, f)
+	q.pushCount++
+
 	return nil
+}
+
+// PushCount returns the number of fossils pushed.
+func (q *DummyQueue) PushCount() int {
+	q.fossilsLock.RLock()
+	defer q.fossilsLock.RUnlock()
+
+	return q.pushCount
 }
 
 // Pop fossils from the queue.
@@ -54,9 +66,18 @@ func (q *DummyQueue) Pop(_ context.Context, count int) ([]*fossilizer.Fossil, er
 
 		fossils = append(fossils, q.fossils[0])
 		q.fossils = q.fossils[1:]
+		q.popCount++
 	}
 
 	return fossils, nil
+}
+
+// PopCount returns the number of fossils popped.
+func (q *DummyQueue) PopCount() int {
+	q.fossilsLock.RLock()
+	defer q.fossilsLock.RUnlock()
+
+	return q.popCount
 }
 
 // Fossils returns all the fossils in the queue for testing purposes.


### PR DESCRIPTION
In case fossilization failed (because of the blockcypher API for example) we push the fossils back to the queue.
This way they will be fossilized at the next batch.
We'll need to watch the queue size though in case a real issue happens (it's easy to setup an alert for that in AWS).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-core/506)
<!-- Reviewable:end -->
