### PR TITLE
postgresstore: store json data instead of protobuf bytes

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,5 +1,14 @@
 # Change log
 
+## 0.4.0 - BREAKING CHANGES
+
+- Postgresstore schema change: data changed back to JSON to allow searches
+
+If you are updating from 0.3.1, you need to run a database migration or drop
+your existing data.
+The migration is pretty simple: list all rows in `store.links` and `store.evidences`,
+deserialize the protobuf `data` and serialize it to JSON instead.
+
 ## 0.3.1 - BREAKING CHANGES
 
 - Repository was renamed to _go-core_

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## Getting started
 
-Read the documentation on our [developer portal](https://developer.stratumn.com).
+Read the documentation on our [developer portal](https://developers.stratumn.com).
 
 ## What's new
 

--- a/postgresstore/stmts.go
+++ b/postgresstore/stmts.go
@@ -126,7 +126,7 @@ var sqlCreate = []string{
 			map_id text NOT NULL,
 			prev_link_hash bytea DEFAULT NULL,
 			tags text[] DEFAULT NULL,
-			data bytea NOT NULL,
+			data jsonb NOT NULL,
 			process text NOT NULL,
 			step text NOT NULL,
 			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -165,7 +165,7 @@ var sqlCreate = []string{
 			id BIGSERIAL PRIMARY KEY,
 			link_hash bytea references store.links(link_hash),
 			provider text NOT NULL,
-			data bytea NOT NULL,
+			data jsonb NOT NULL,
 			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			UNIQUE(link_hash, provider)

--- a/store/storetestcases/evidencestore.go
+++ b/store/storetestcases/evidencestore.go
@@ -71,6 +71,9 @@ func (f Factory) TestEvidenceStore(t *testing.T) {
 		storedEvidences, err := s.GetEvidences(ctx, linkHash)
 		assert.NoError(t, err, "s.GetEvidences()")
 		assert.Equal(t, 6, len(storedEvidences), "Invalid number of evidences")
-		assert.EqualValues(t, e.Backend, storedEvidences.GetEvidence("TMPop", "42").Backend, "Invalid evidence backend")
+
+		stored := storedEvidences.GetEvidence("TMPop", "42")
+		assert.NotNil(t, stored)
+		assert.EqualValues(t, e.Backend, stored.Backend, "Invalid evidence backend")
 	})
 }


### PR DESCRIPTION
This change will be tagged as version 0.4.0.
I'll wait a bit before merging this PR to make sure our different environments have correctly started using 0.3.1 instead of master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-core/514)
<!-- Reviewable:end -->
