### PR TITLE
store: create links batch

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## 0.3.2
+
+Added support for batch link creation.
+It is now possible to create multiple links atomically.
+
 ## 0.3.1 - BREAKING CHANGES
 
 - Repository was renamed to _go-core_

--- a/postgresstore/benchmark_test.go
+++ b/postgresstore/benchmark_test.go
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package postgresstore
+package postgresstore_test
 
 import (
 	"testing"
 
+	"github.com/stratumn/go-core/postgresstore"
 	"github.com/stratumn/go-core/store"
 	"github.com/stratumn/go-core/store/storetestcases"
 )
@@ -33,8 +34,10 @@ func BenchmarkStore(b *testing.B) {
 	factory.RunKeyValueStoreBenchmarks(b)
 }
 
-func createStoreB() (*Store, error) {
-	a, err := New(&Config{URL: "postgres://postgres@localhost/postgres?sslmode=disable"})
+func createStoreB() (*postgresstore.Store, error) {
+	a, err := postgresstore.New(&postgresstore.Config{
+		URL: "postgres://postgres@localhost/postgres?sslmode=disable",
+	})
 	if err := a.Create(); err != nil {
 		return nil, err
 	}
@@ -52,16 +55,16 @@ func createKeyValueStoreB() (store.KeyValueStore, error) {
 	return createStore()
 }
 
-func freeStoreB(s *Store) {
+func freeStoreB(s *postgresstore.Store) {
 	if err := s.Drop(); err != nil {
 		panic(err)
 	}
 }
 
 func freeAdapterB(s store.Adapter) {
-	freeStore(s.(*Store))
+	freeStore(s.(*postgresstore.Store))
 }
 
 func freeKeyValueStoreB(s store.KeyValueStore) {
-	freeStore(s.(*Store))
+	freeStore(s.(*postgresstore.Store))
 }

--- a/postgresstore/benchmark_test.go
+++ b/postgresstore/benchmark_test.go
@@ -48,11 +48,11 @@ func createStoreB() (*postgresstore.Store, error) {
 }
 
 func createAdapterB() (store.Adapter, error) {
-	return createStore()
+	return createStoreB()
 }
 
 func createKeyValueStoreB() (store.KeyValueStore, error) {
-	return createStore()
+	return createStoreB()
 }
 
 func freeStoreB(s *postgresstore.Store) {
@@ -62,9 +62,9 @@ func freeStoreB(s *postgresstore.Store) {
 }
 
 func freeAdapterB(s store.Adapter) {
-	freeStore(s.(*postgresstore.Store))
+	freeStoreB(s.(*postgresstore.Store))
 }
 
 func freeKeyValueStoreB(s store.KeyValueStore) {
-	freeStore(s.(*postgresstore.Store))
+	freeStoreB(s.(*postgresstore.Store))
 }

--- a/postgresstore/postgresstore.go
+++ b/postgresstore/postgresstore.go
@@ -125,9 +125,11 @@ func (a *Store) GetInfo(ctx context.Context) (interface{}, error) {
 // NewBatch implements github.com/stratumn/go-core/store.Adapter.NewBatch.
 func (a *Store) NewBatch(ctx context.Context) (store.Batch, error) {
 	for b := range a.batches {
+		b.lock.RLock()
 		if b.done {
 			delete(a.batches, b)
 		}
+		b.lock.RUnlock()
 	}
 
 	tx, err := a.db.Begin()

--- a/postgresstore/postgresstore_test.go
+++ b/postgresstore/postgresstore_test.go
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package postgresstore
+package postgresstore_test
 
 import (
 	"testing"
 
+	"github.com/stratumn/go-core/postgresstore"
 	"github.com/stratumn/go-core/store"
 	"github.com/stratumn/go-core/store/storetestcases"
 	"github.com/stratumn/go-core/tmpop/tmpoptestcases"
@@ -42,8 +43,10 @@ func TestPostgresTMPop(t *testing.T) {
 	}.RunTests(t)
 }
 
-func createStore() (*Store, error) {
-	a, err := New(&Config{URL: "postgres://postgres@localhost:5433/sdk_test?sslmode=disable"})
+func createStore() (*postgresstore.Store, error) {
+	a, err := postgresstore.New(&postgresstore.Config{
+		URL: "postgres://postgres@localhost:5433/sdk_test?sslmode=disable",
+	})
 	if err := a.Create(); err != nil {
 		return nil, err
 	}
@@ -61,7 +64,7 @@ func createKeyValueStore() (store.KeyValueStore, error) {
 	return createStore()
 }
 
-func freeStore(s *Store) {
+func freeStore(s *postgresstore.Store) {
 	if err := s.Drop(); err != nil {
 		panic(err)
 	}
@@ -71,11 +74,11 @@ func freeStore(s *Store) {
 }
 
 func freeAdapter(s store.Adapter) {
-	freeStore(s.(*Store))
+	freeStore(s.(*postgresstore.Store))
 }
 
 func freeKeyValueStore(s store.KeyValueStore) {
-	freeStore(s.(*Store))
+	freeStore(s.(*postgresstore.Store))
 }
 
 func createAdapterTMPop() (store.Adapter, store.KeyValueStore, error) {

--- a/postgresstore/segment.go
+++ b/postgresstore/segment.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stratumn/go-core/monitoring/errorcode"
 	"github.com/stratumn/go-core/store"
 	"github.com/stratumn/go-core/types"
+	"github.com/stratumn/go-core/validation/validators"
 )
 
 // CreateLink implements github.com/stratumn/go-core/store.Adapter.CreateLink.
@@ -46,6 +47,9 @@ func (s *scopedStore) CreateLink(ctx context.Context, link *chainscript.Link) (c
 	parent, err := s.GetSegment(ctx, link.PrevLinkHash())
 	if err != nil {
 		return linkHash, err
+	}
+	if parent == nil {
+		return linkHash, validators.ErrParentNotFound
 	}
 
 	parentDegree := parent.Link.Meta.OutDegree

--- a/store/API.md
+++ b/store/API.md
@@ -58,6 +58,79 @@ HTTP/1.1 200 OK
 }
 ```
 
+## POST /batch/links
+
+Add a collection of JSON-encoded links to the store atomically.
+If one of the links is invalid nothing will be added to the store.
+
+```http
+POST /batch/links
+[
+  {
+    "version": "1.0.0",
+    "data": "ewogICJvd25lciI6ICJhbGljZSIKfQ==",
+    "meta": {
+      "clientId": "github.com/stratumn/go-chainscript",
+      "outDegree": 3,
+      "process": { "name": "asset-tracker", "state": "asset-created" },
+      "mapId": "123456",
+      "action": "init",
+      "step": "init",
+      "tags": ["alice"]
+    }
+  },
+  {
+    "version": "1.0.0",
+    "meta": {
+      "clientId": "github.com/stratumn/go-chainscript",
+      "outDegree": -1,
+      "process": { "name": "voting-protocol" },
+      "mapId": "234567",
+      "action": "create",
+      "step": "create",
+      "tags": ["bob"]
+    }
+  }
+]
+
+HTTP/1.1 200 OK
+[
+  {
+    "link": {
+      "version": "1.0.0",
+      "data": "ewogICJvd25lciI6ICJhbGljZSIKfQ==",
+      "meta": {
+        "clientId": "github.com/stratumn/go-chainscript",
+        "outDegree": 3,
+        "process": { "name": "asset-tracker", "state": "asset-created" },
+        "mapId": "123456",
+        "action": "init",
+        "step": "init",
+        "tags": ["alice"]
+      }
+    },
+    "meta": {
+      "linkHash": "z+w01ZMHQ4dyuA1ro5BcKM5NPV6vpgLmZ0XjDTwf7Hw="
+    }
+  },
+  {
+    "link": {
+      "version": "1.0.0",
+      "meta": {
+        "clientId": "github.com/stratumn/go-chainscript",
+        "outDegree": -1,
+        "process": { "name": "voting-protocol" },
+        "mapId": "234567",
+        "action": "create",
+        "step": "create",
+        "tags": ["bob"]
+      }
+    },
+    "meta": { "linkHash": "9s1Zv+dWfcUzrqUgsbfgeVykRz0tq5bCaPLZMYMOQ4c=" }
+  }
+]
+```
+
 ## POST /evidences/:linkHash
 
 Add a JSON-encoded evidence to a link (identified by its hex-encoded hash).

--- a/store/errors.go
+++ b/store/errors.go
@@ -24,4 +24,5 @@ var (
 	ErrOutDegreeNotSupported   = errors.New("out degree is not supported by the current implementation")
 	ErrUniqueMapEntry          = errors.New("unique map entry is set and map already has an initial link")
 	ErrReferencingNotSupported = errors.New("filtering on referencing segments is not supported by the current implementation")
+	ErrBatchFailed             = errors.New("cannot add to batch: failures have been detected")
 )

--- a/store/storetestcases/batch.go
+++ b/store/storetestcases/batch.go
@@ -88,7 +88,7 @@ func (f Factory) TestBatch(t *testing.T) {
 		}
 	})
 
-	t.Run("CreateLink should rejects links after failure", func(t *testing.T) {
+	t.Run("CreateLink should reject links after failure", func(t *testing.T) {
 		ctx := context.Background()
 		b := initBatch(t, a)
 

--- a/store/storetesting/mockadapter.go
+++ b/store/storetesting/mockadapter.go
@@ -186,7 +186,7 @@ type MockNewBatch struct {
 	CalledCount int
 
 	// An optional implementation of the function.
-	Fn func() store.Batch
+	Fn func() (store.Batch, error)
 }
 
 // MockSetValue mocks the SetValue function.
@@ -340,7 +340,7 @@ func (a *MockAdapter) NewBatch(ctx context.Context) (store.Batch, error) {
 	a.MockNewBatch.CalledCount++
 
 	if a.MockNewBatch.Fn != nil {
-		return a.MockNewBatch.Fn(), nil
+		return a.MockNewBatch.Fn()
 	}
 
 	return &MockBatch{}, nil


### PR DESCRIPTION
Add the option to create multiple links in an atomic batch.
I chose to make it explicit that it's a batch by using a new route (it makes it easier for backwards-compatibility too). It's not unrealistic at some point to use the `/links` route and make it accept a more complex payload (collection of links + a boolean to choose what to do in case of error: atomic or not).

Fixes #515

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-core/516)
<!-- Reviewable:end -->
