### PR TITLE
postgresstore: link json encoding

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,5 +1,15 @@
 # Change log
 
+## 0.4.0 - BREAKING CHANGES
+
+- Postgresstore schema change: data changed back to JSON to allow search
+
+If you are updating from 0.3.x, you need to run a database migration or drop
+your existing data.
+The migration is pretty simple: list all rows in the `store.links` and `store.evidences`
+tables, deserialize the protobuf `data` and serialize it to JSON instead.
+You'll also need to change the column format from `bytea` to `jsonb`.
+
 ## 0.3.2
 
 Added support for batch link creation.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## Getting started
 
-Read the documentation on our [developer portal](https://developer.stratumn.com).
+Read the documentation on our [developer portal](https://developers.stratumn.com).
 
 ## What's new
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## Getting started
 
-Read the documentation on our [developer portal](https://developers.stratumn.com).
+Read the documentation on our [developer portal](https://developer.stratumn.com).
 
 ## What's new
 

--- a/postgresstore/segment.go
+++ b/postgresstore/segment.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 
 	"github.com/lib/pq"
 	"github.com/stratumn/go-chainscript"
@@ -34,7 +35,7 @@ func (s *scopedStore) CreateLink(ctx context.Context, link *chainscript.Link) (c
 		return linkHash, types.WrapError(err, errorcode.InvalidArgument, store.Component, "could not hash link")
 	}
 
-	data, err := chainscript.MarshalLink(link)
+	data, err := json.Marshal(link)
 	if err != nil {
 		return linkHash, types.WrapError(err, errorcode.InvalidArgument, store.Component, "could not marshal link")
 	}
@@ -186,7 +187,7 @@ func (s *scopedStore) createLinkInTx(
 		link.Meta.MapId,
 		prevLinkHash,
 		pq.Array(link.Meta.Tags),
-		data,
+		string(data),
 		link.Meta.Process.Name,
 		link.Meta.Step,
 	)
@@ -285,9 +286,9 @@ func scanLinkAndEvidences(rows *sql.Rows, segments *types.SegmentSlice, totalCou
 	for rows.Next() {
 		var (
 			linkHash     chainscript.LinkHash
-			linkData     []byte
+			linkData     string
 			link         *chainscript.Link
-			evidenceData []byte
+			evidenceData sql.NullString
 			evidence     *chainscript.Evidence
 			err          error
 		)
@@ -303,7 +304,7 @@ func scanLinkAndEvidences(rows *sql.Rows, segments *types.SegmentSlice, totalCou
 		}
 
 		if !bytes.Equal(currentHash, linkHash) {
-			link, err = chainscript.UnmarshalLink(linkData)
+			err = json.Unmarshal([]byte(linkData), &link)
 			if err != nil {
 				return types.WrapError(err, errorcode.InvalidArgument, store.Component, "could not unmarshal link")
 			}
@@ -322,8 +323,8 @@ func scanLinkAndEvidences(rows *sql.Rows, segments *types.SegmentSlice, totalCou
 			*segments = append(*segments, currentSegment)
 		}
 
-		if len(evidenceData) > 0 {
-			evidence, err = chainscript.UnmarshalEvidence(evidenceData)
+		if evidenceData.Valid && len(evidenceData.String) > 0 {
+			err = json.Unmarshal([]byte(evidenceData.String), &evidence)
 			if err != nil {
 				return types.WrapError(err, errorcode.InvalidArgument, store.Component, "could not unmarshal evidence")
 			}

--- a/postgresstore/stmts.go
+++ b/postgresstore/stmts.go
@@ -126,7 +126,7 @@ var sqlCreate = []string{
 			map_id text NOT NULL,
 			prev_link_hash bytea DEFAULT NULL,
 			tags text[] DEFAULT NULL,
-			data bytea NOT NULL,
+			data jsonb NOT NULL,
 			process text NOT NULL,
 			step text NOT NULL,
 			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -165,7 +165,7 @@ var sqlCreate = []string{
 			id BIGSERIAL PRIMARY KEY,
 			link_hash bytea references store.links(link_hash),
 			provider text NOT NULL,
-			data bytea NOT NULL,
+			data jsonb NOT NULL,
 			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			UNIQUE(link_hash, provider)

--- a/store/storetestcases/evidencestore.go
+++ b/store/storetestcases/evidencestore.go
@@ -71,6 +71,9 @@ func (f Factory) TestEvidenceStore(t *testing.T) {
 		storedEvidences, err := s.GetEvidences(ctx, linkHash)
 		assert.NoError(t, err, "s.GetEvidences()")
 		assert.Equal(t, 6, len(storedEvidences), "Invalid number of evidences")
-		assert.EqualValues(t, e.Backend, storedEvidences.GetEvidence("TMPop", "42").Backend, "Invalid evidence backend")
+
+		stored := storedEvidences.GetEvidence("TMPop", "42")
+		assert.NotNil(t, stored)
+		assert.EqualValues(t, e.Backend, stored.Backend, "Invalid evidence backend")
 	})
 }


### PR DESCRIPTION
Encoding link and evidence data as JSON instead of protobuf.
This enables JSON field indexing in postgres which can be nice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-core/517)
<!-- Reviewable:end -->
