### PR TITLE
Fix fossilizer issue where utxo inputs are lower than transaction fee

### DIFF
--- a/blockchain/btc/blockcypher/blockcypher.go
+++ b/blockchain/btc/blockcypher/blockcypher.go
@@ -99,7 +99,7 @@ func (c *Client) FindUnspent(ctx context.Context, address *types.ReversedBytes20
 	accountBalance.With(prometheus.Labels{accountAddress: addr}).Set(float64(res.Total))
 
 	for _, TXRef := range addrInfo.TXRefs {
-		output := btc.Output{Index: TXRef.TXOutputN}
+		output := btc.Output{Index: TXRef.TXOutputN, Value: TXRef.Value}
 
 		if err = output.TXHash.Unstring(TXRef.TXHash); err != nil {
 			return

--- a/blockchain/btc/btc.go
+++ b/blockchain/btc/btc.go
@@ -88,6 +88,7 @@ type Output struct {
 	TXHash   types.ReversedBytes32
 	PKScript []byte
 	Index    int
+	Value    int
 }
 
 // UnspentResult contains the result of a call to UnspentFinder.FindUnspent.


### PR DESCRIPTION
I couldn't find a proper solution to the issue so I used a quickfix instead.
The issue is described in detail with the fix.
The drawback to this solution is that UTXOs that are lower than the transaction fee (15000 satoshis) will never be used by the fossilizer, and we'll have to manually "merge" them from time to time (create a transaction from some wallet with all the low UTXO as inputs and only one UTXO as output, to the same address).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-core/525)
<!-- Reviewable:end -->
